### PR TITLE
Added ssh client for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,19 @@ version: 2
 jobs:
   build:
     docker:
-      - image: ubuntu:14.04
+      - image: phusion/baseimage
     working_directory: ~/circulate
     steps:
-      - checkout
       - run:
           name: Install Python Pip JDK
           command: |
-            apt-get update && apt-get install -y python python-pip python-dev software-properties-common git
+            apt-get -qq update
+            apt-get -y install git openssh-client python python-pip python-dev software-properties-common
             add-apt-repository -y ppa:openjdk-r/ppa
             apt-get update && apt-get install -y openjdk-8-jdk
             export JDK_HOME=/usr/lib/jvm/java-8-openjdk-amd64
             export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      - checkout
       - run:
           name: Private Pypi Config Setup
           command: |


### PR DESCRIPTION
Added following steps to fix circleci builds:
* Change docker image to  [phusion/baseimage](http://phusion.github.io/baseimage-docker/)
* Perform update in a separate step
* Checkout after installing git/ssh